### PR TITLE
pass the errors to the returned stream

### DIFF
--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -157,12 +157,12 @@ exports.applyDelta = (srcImage) ->
 		.then ->
 			# rsync doesn't fsync by itself
 			utils.waitPidAsync(spawn('sync'))
-		.catch (e) ->
-			if e?.code in DELTA_OUT_OF_SYNC_CODES
-				throw OutOfSyncError('Incompatible image')
-			else
-				throw e
 		.then ->
 			deltaStream.emit('id', dstId)
+	.catch (e) ->
+		if e?.code in DELTA_OUT_OF_SYNC_CODES
+			deltaStream.emit('error', new OutOfSyncError('Incompatible image'))
+		else
+			deltaStream.emit('error', e)
 
 	return deltaStream

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-delta",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Generate binary filesystem diffs between docker images to speed up distribution",
   "main": "lib/docker-delta.js",
   "scripts": {


### PR DESCRIPTION
applyDelta returns a stream, not the promise chain. We have to convert
any rejections to error events

Signed-off-by: Petros Angelatos petrosagg@gmail.com
