### PR TITLE
Cleanup docker image when delta application fails

### DIFF
--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -158,9 +158,15 @@ exports.applyDelta = (srcImage) ->
 		.then ->
 			deltaStream.emit('id', dstId)
 	.catch (e) ->
-		if e?.code in DELTA_OUT_OF_SYNC_CODES
-			deltaStream.emit('error', new OutOfSyncError('Incompatible image'))
-		else
-			deltaStream.emit('error', e)
+		# If the process failed for whatever reason, cleanup the empty image
+		dstId.then (dstId) ->
+			dockerUtils.docker.getImage(src).removeAsync()
+			.catch (e) ->
+				deltaStream.emit('error', e)
+		.then ->
+			if e?.code in DELTA_OUT_OF_SYNC_CODES
+				deltaStream.emit('error', new OutOfSyncError('Incompatible image'))
+			else
+				deltaStream.emit('error', e)
 
 	return deltaStream

--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -35,8 +35,6 @@ exports.createDelta = (srcImage, destImage, v2 = true) ->
 		.map (rootDir) ->
 			path.join(rootDir, '/')
 		.spread(rsync.createRsyncStream)
-		.catch (e) ->
-			deltaStream.emit('error', e)
 
 	# We also retrieve the container config for the image
 	config = docker.getImage(destImage).inspectAsync().get('Config')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-delta",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Generate binary filesystem diffs between docker images to speed up distribution",
   "main": "lib/docker-delta.js",
   "scripts": {


### PR DESCRIPTION
While trying to apply the delta, the library creates a new docker image
by snapshotting the source image. Make sure we clean up after ourselves
in case the application fails.
