### PR TITLE
use docker.version() to get the server version

### DIFF
--- a/lib/docker-toolbelt.coffee
+++ b/lib/docker-toolbelt.coffee
@@ -47,14 +47,15 @@ createChainIdFromParent = (parent, dgsts) ->
 Docker::imageRootDir = (image) ->
 	Promise.all [
 		@infoAsync()
+		@versionAsync().get('Version')
 		@getImage(image).inspectAsync()
 	]
-	.spread (dockerInfo, imageInfo) ->
+	.spread (dockerInfo, dockerVersion, imageInfo) ->
 		dkroot = dockerInfo.DockerRootDir
 
 		imageId = imageInfo.Id
 
-		if semver.gte(dockerInfo.ServerVersion, '1.10.0')
+		if semver.gte(dockerVersion, '1.10.0')
 			[ hashType, hash ] = imageId.split(':')
 
 			fs.readFileAsync(path.join(dkroot, 'image/btrfs/imagedb/content', hashType, hash))


### PR DESCRIPTION
Older versions of the docker daemon don't report the server version in
the docker.info() response.

Signed-off-by: Petros Angelatos petrosagg@gmail.com

@Page- 
