### PR TITLE
Export the docker object

### DIFF
--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -10,7 +10,7 @@ btrfs = require './btrfs'
 utils = require './utils'
 Docker = require './docker-toolbelt'
 
-docker = new Docker()
+exports.docker = docker = new Docker()
 
 DELTA_OUT_OF_SYNC_CODES = [23, 24]
 


### PR DESCRIPTION
...to allow usage of imageRootDir and createEmptyImage

We'll need this for resin-io/resin-supervisor#204
