### PR TITLE
Use a hardlink copy to support AUFS (and OverlayFS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Use a hardlink copy to support AUFS (and OverlayFS)
+
 # v0.0.12
 
 * Use docker-toolbelt from npm module

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.0",
-    "docker-toolbelt": "^1.0.0",
+    "docker-toolbelt": "^1.3.0",
     "dockerode": "^2.2.10",
     "event-stream": "^3.3.2",
     "mkfifo": "^0.1.5",


### PR DESCRIPTION
Depends on resin-io-modules/docker-toolbelt#4 being merged and published as 1.3.0.
