### PR TITLE
remove arbitrary 6 minute timeout

### DIFF
--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -109,7 +109,6 @@ nullDisposer = ->
 
 hardlinkCopy = (srcRoot, dstRoot, linkDests) ->
 	rsyncArgs = [
-		'--timeout', '300'
 		'--archive'
 		'--delete'
 	]
@@ -156,7 +155,6 @@ exports.applyDelta = (srcImage) ->
 							throw new Error("Unsupported driver #{dockerDriver}")
 				.then ->
 					rsyncArgs = [
-						'--timeout', '300'
 						'--archive'
 						'--delete'
 						'--read-batch', '-'


### PR DESCRIPTION
This timeout was put there because of an implementation issue with
rsync that was fixed in resin-supervisor#425

Change-type: patch
Signed-off-by: Petros Angelatos <petrosagg@gmail.com>