### PR TITLE
Larger rsync exit timeout, and replace the mkfifo dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# node-docker-delta
+
+node.js library to create and apply rsync-based docker image binary diffs

--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -14,6 +14,11 @@ docker = new Docker()
 # code 19 isn't found in rsync's man pages.
 DELTA_OUT_OF_SYNC_CODES = [ 19, 23, 24 ]
 
+# We set a large timeout (10 minutes) for rsync to exit after applying the batch.
+# For most cases 5 seconds is more than enough, but in systems with slow IO
+# it can be a bit longer.
+RSYNC_EXIT_TIMEOUT = 10 * 60 * 1000
+
 exports.OutOfSyncError = class OutOfSyncError extends TypedError
 
 # Takes two strings `srcImage` and `destImage` which represent docker images
@@ -144,7 +149,7 @@ applyBatch = (rsync, batch, timeout, log) ->
 		# if rsync exited cleanly, `waitAsync` will resolve and the chain continues.
 		# for any other case, a short timeout will ensure we don't wait forever and
 		# manually kill rsync below.
-		rsync.waitAsync().timeout(5000)
+		rsync.waitAsync().timeout(RSYNC_EXIT_TIMEOUT)
 		.tap ->
 			log('rsync exited cleanly')
 		.tapCatch (err) ->

--- a/lib/rsync.coffee
+++ b/lib/rsync.coffee
@@ -2,8 +2,7 @@ Promise = require 'bluebird'
 fs = require 'fs'
 tmp = require 'tmp'
 path = require 'path'
-mkfifoSync = require('mkfifo').mkfifoSync
-{ spawn } = require './utils'
+{ spawn, mkfifoSync } = require './utils'
 
 exports.createRsyncStream = (src, dest, ioTimeout, log) ->
 	new Promise (resolve, reject) ->
@@ -14,7 +13,7 @@ exports.createRsyncStream = (src, dest, ioTimeout, log) ->
 
 			pipePath = path.join(tmpDirPath, 'rsync.pipe')
 
-			mkfifoSync(pipePath, 0o600)
+			mkfifoSync(pipePath)
 
 			# To produce the delta that takes us from `src` to `dest`
 			# we have to tell rsync to copy `dest` to `src`

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,4 +1,4 @@
-{ spawn } = require 'child_process'
+{ spawn, execSync } = require 'child_process'
 Promise = require 'bluebird'
 
 # Similar to waitpid(), it gets an instance of ChildProcess and returns a
@@ -38,3 +38,6 @@ exports.spawn = (cmd, args, opts) ->
 	ps.waitAsync = ->
 		waitPidAsync(cmd, ps, processStatus)
 	return ps
+
+exports.mkfifoSync = (fifoPath) ->
+	execSync("mkfifo -m 0600 #{fifoPath}")

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "docker-toolbelt": "^3.0.1",
     "dockerode": "^2.5.0",
     "event-stream": "^3.3.2",
-    "mkfifo": "^0.1.5",
     "readable-stream": "^2.1.2",
     "semver": "^5.1.0",
     "tar-stream": "^1.5.2",


### PR DESCRIPTION
This solves unnecessary timeouts when disk IO is very slow.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablocarranza@gmail.com>