### PR TITLE
Fix rsync delta application on node 8

### DIFF
--- a/Dockerfile.node10.test
+++ b/Dockerfile.node10.test
@@ -45,11 +45,9 @@ RUN wget -q -O /tmp/docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/L
 
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
+COPY . /usr/src/app/
 
 RUN npm install --unsafe-perm  && npm cache clean --force
-
-COPY . /usr/src/app
 
 COPY test/services/ /etc/systemd/system/
 

--- a/Dockerfile.node6.test
+++ b/Dockerfile.node6.test
@@ -45,11 +45,9 @@ RUN wget -q -O /tmp/docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/L
 
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
+COPY . /usr/src/app
 
 RUN npm install --unsafe-perm  && npm cache clean
-
-COPY . /usr/src/app
 
 COPY test/services/ /etc/systemd/system/
 

--- a/Dockerfile.node8.test
+++ b/Dockerfile.node8.test
@@ -45,11 +45,9 @@ RUN wget -q -O /tmp/docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/L
 
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
+COPY . /usr/src/app
 
 RUN npm install --unsafe-perm  && npm cache clean --force
-
-COPY . /usr/src/app
 
 COPY test/services/ /etc/systemd/system/
 

--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -220,6 +220,13 @@ exports.applyDelta = (srcImage, { timeout = 0, log } = {}) ->
 					log("Spawning rsync with arguments #{rsyncArgs.join(' ')}")
 
 					rsync = spawn('rsync', rsyncArgs, opts)
+					# Post node 8, if the delta stream is still attached to the
+					# stdin stream on rsync, it will never close, and the process
+					# can hang. We force close here. This also works pre-node 8,
+					# as ending a stream twice is fine
+					rsync.on 'end', ->
+						rsync.stdin.end()
+
 					applyBatch(rsync, deltaStream, timeout, log)
 					.tap ->
 						log('rsync exited successfully')

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Generate binary filesystem diffs between docker images to speed up distribution",
   "main": "lib/docker-delta",
   "scripts": {
-    "prepublishOnly": "npm run lint && coffee -c lib",
+    "prepare": "coffee -c lib",
     "lint": "resin-lint lib",
+    "pretest": "npm run lint",
     "test": "bash ./test.sh",
     "versionist": "versionist"
   },


### PR DESCRIPTION
We explicitly close the stdin stream for the rsync process when the
    process ends. When the data is piped into the stdin, it doesn't always
    close the stdin stream when the process finishes. This causes the
    application to hang indefinitely