### PR TITLE
Use the correct process event when force closing rsync stdin

### DIFF
--- a/lib/docker-delta.coffee
+++ b/lib/docker-delta.coffee
@@ -224,7 +224,7 @@ exports.applyDelta = (srcImage, { timeout = 0, log } = {}) ->
 					# stdin stream on rsync, it will never close, and the process
 					# can hang. We force close here. This also works pre-node 8,
 					# as ending a stream twice is fine
-					rsync.on 'end', ->
+					rsync.on 'close', ->
 						rsync.stdin.end()
 
 					applyBatch(rsync, deltaStream, timeout, log)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>