### PR TITLE
Export OutOfSyncError

### DIFF
--- a/lib/docker-delta.ts
+++ b/lib/docker-delta.ts
@@ -12,7 +12,7 @@ const DELTA_OUT_OF_SYNC_CODES = [19, 23, 24];
 
 const RSYNC_EXIT_TIMEOUT = 10 * 60 * 1000;
 
-class OutOfSyncError extends TypedError {
+export class OutOfSyncError extends TypedError {
 	// noop
 }
 


### PR DESCRIPTION
The export was lost during the [migration from CoffeeScript to JavaScript](https://github.com/balena-io-modules/node-docker-delta/commit/9600706c47334a800636a97dc5e367e57f46d637#diff-c440d0187a0693cb8ff06e40fa4d7f3df979918586c0948cfef38594237ff533L22) but the supervisor has been [assuming the export is available](https://github.com/balena-os/balena-supervisor/blob/master/src/lib/docker-utils.ts#L235) since then. This is required to fix v2 delta support in balena-os/balena-supervisor#2350

Change-type: minor