### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -7,6 +7,11 @@ on:
       - "main"
       - "master"
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "prepare": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module && npx tsc"
   },
   "author": "Balena Ltd.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/balena-io-modules/node-docker-delta.git"
+  },
   "license": "Apache-2.0",
   "devDependencies": {
     "@balena/lint": "^9.3.12",


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch