### PR TITLE
Fix linting error

### DIFF
--- a/lib/docker-delta.ts
+++ b/lib/docker-delta.ts
@@ -105,7 +105,7 @@ function parseDeltaStream(input: stream.PassThrough) {
 						reject(new Error('Unknown version: ' + metadata.version));
 					}
 				} catch (error) {
-					reject(error as Error);
+					reject(error instanceof Error ? error : new Error(String(error)));
 				}
 			}
 		};


### PR DESCRIPTION
Change-type: patch

---

This is to fix a linting error currently blocking PRs in this repo:
<img width="1205" height="326" alt="image" src="https://github.com/user-attachments/assets/7f4c6caf-b63b-4674-8e19-1f26266cb97b" />

See: https://github.com/balena-io-modules/node-docker-delta/actions/runs/27197309381/job/80292338925?pr=78